### PR TITLE
also allow resource and client_secret params for auth code grant

### DIFF
--- a/src/EasyBib/OAuth2/Client/AuthorizationCodeGrant/ClientConfig.php
+++ b/src/EasyBib/OAuth2/Client/AuthorizationCodeGrant/ClientConfig.php
@@ -25,6 +25,8 @@ class ClientConfig
     private static $permittedParams = [
         'client_id',
         'redirect_uri',
+        'client_secret',
+        'resource',
     ];
 
     /**

--- a/src/EasyBib/OAuth2/Client/AuthorizationCodeGrant/TokenRequest.php
+++ b/src/EasyBib/OAuth2/Client/AuthorizationCodeGrant/TokenRequest.php
@@ -66,11 +66,20 @@ class TokenRequest implements TokenRequestInterface
      */
     private function getParams()
     {
-        return [
+        $clientConfig = $this->clientConfig->getParams();
+        $params = [
             'grant_type' => self::GRANT_TYPE,
             'code' => $this->authorizationResponse->getCode(),
-            'redirect_uri' => $this->clientConfig->getParams()['redirect_uri'],
-            'client_id' => $this->clientConfig->getParams()['client_id'],
+            'redirect_uri' => $clientConfig['redirect_uri'],
+            'client_id' => $clientConfig['client_id'],
         ];
+        $addOptionalParam = function ($key) use (&$params, $clientConfig) {
+            if (isset($clientConfig[$key])) {
+                $params[$key] = $clientConfig[$key];
+            }
+        };
+        $addOptionalParam('client_secret');
+        $addOptionalParam('resource');
+        return $params;
     }
 }


### PR DESCRIPTION
To support office365. Not super sure if the "resource" should really be in the *client* config but I guess it's okay.